### PR TITLE
pin mujoco

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from setuptools import setup
 
 setup(
     name="latent-brax",
-    version="0.1.1",
+    version="0.1.2",
     description=("A differentiable physics engine written in JAX."),
     author="Brax Authors",
     author_email="no-reply@google.com",
@@ -49,7 +49,7 @@ setup(
         "jaxlib",
         "jaxopt",
         "jinja2",
-        "mujoco",
+        "mujoco==2.3.7",
         "numpy",
         "optax",
         "Pillow",


### PR DESCRIPTION
Pin mujoco to "mujoco==2.3.7",

tests are failing with newer versions (3.0.0) https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/835098263999/projects/latent-agency-on-merge/build/latent-agency-on-merge%3Af210ba47-2af4-49f0-8eec-3c8423ac158b?region=eu-west-2